### PR TITLE
Fix `ADOs` creating `reshape` object

### DIFF
--- a/src/ADOs.jl
+++ b/src/ADOs.jl
@@ -62,7 +62,7 @@ Generate the object of auxiliary density operators for HEOM model.
 - `parity::AbstractParity` : the parity label (`EVEN` or `ODD`). Default to `EVEN`.
 """
 function ADOs(ρ::QuantumObject, N::Int = 1, parity::AbstractParity = EVEN)
-    _ρ = sparsevec(ket2dm(ρ).data)
+    _ρ = sparse(vec(ket2dm(ρ).data)) # to avoid _ρ begin reshape type, which cannot do _ρ.nzind and _ρ.nzval
     return ADOs(sparsevec(_ρ.nzind, _ρ.nzval, N * length(_ρ)), ρ.dimensions, N, parity)
 end
 ADOs(ρ, N::Int = 1, parity::AbstractParity = EVEN) =


### PR DESCRIPTION
## Checklist
Thank you for contributing to `HierarchicalEOM.jl`! Please make sure you have finished the following tasks before opening the PR.

- [ ] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [ ] Any code changes were done in a way that does not break public API.
- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
`ADOs(ρ)` use `reshape` type within when `ρ` has sparse data. Yet `reshape` type does not have field `nzind` and `nzval` to build the extended ADOs vector from the RDO vector.