### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/CUDA_Ext.yml
+++ b/.buildkite/CUDA_Ext.yml
@@ -16,8 +16,7 @@ steps:
             - src
             - ext
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     env:
       GROUP: "CUDA_Ext"
       SECRET_CODECOV_TOKEN: "LnZuLkirUZtLqOR8hrOChoiOgAKtHth5pTmttecSxdwANQSnwvvOZJRlWEg5otIVHfE2VMwDEitqFkQaSFxR8oO/7rl8Pxe2OiJCqyxosy5YYL5YLdfsUay2tBPau/lAy66dmB70LGhfyf7uUhpFKC2nlvGO+eyv0GKZ4JBu4PUiaLPOgkozGufQupkmOFGmpsWHo+a4HKN4/cOsIhF3P9JOWsBydlTtBMfFbG19qDGtUnrhaOfqitpoLo4h56kNDQstDnlApirMXS3B7tXMMxiUj/aWWE7ZQdDPrRrZMCv1eDcrRJktPWgJM1fUEQSy5mTSdEsyRDHp7JM8fdCamA==;U2FsdGVkX1/WQ6K/3LSCe5+vGyBKxftywEmwKVjgDXDW2mbj/BGoB3x7Vfx0LnTAvgu/DycV7AbhlsydNqmVBw=="

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
         !build.pull_request.draft      &&
         (build.branch =~ /main/ || build.pull_request.base_branch =~ /main/)
     agents:
-      queue: "juliagpu"
+      queue: "cuda"
     plugins:
       - staticfloat/forerunner: # only trigger the pipeline if the following folders are updated
           watch:


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"` instead of `queue: "juliagpu"` combined with a `cuda` tag. The forerunner launcher step in `pipeline.yml` was also moved to the `cuda` queue, as this repository's GPU jobs all target CUDA.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)